### PR TITLE
test: expect 201 for assistant creation

### DIFF
--- a/backend/tests/api/v1/test_assistants.py
+++ b/backend/tests/api/v1/test_assistants.py
@@ -32,9 +32,9 @@ async def test_create_and_read_assistant(client: AsyncClient, db):
         "description": "This is a test assistant created via API test."
     }
     response = await client.post("/api/v1/assistants/", json=new_assistant_data)
-    
+
     # 3. 作成が成功したかを確認
-    assert response.status_code == status.HTTP_200_OK
+    assert response.status_code == status.HTTP_201_CREATED
     created_assistant = response.json()
     assert created_assistant["name"] == new_assistant_data["name"]
     assert "id" in created_assistant


### PR DESCRIPTION
## Summary
- expect 201 CREATED when creating a new assistant in tests

## Testing
- `DATABASE_URL=postgresql+asyncpg://ai_secretary_user:ai_secretary_password@postgres_test:5432/ai_secretary_test pytest backend/tests/api/v1/test_assistants.py -q` *(fails: [Errno -2] Name or service not known)*

------
https://chatgpt.com/codex/tasks/task_e_68c30507dc6c8330b52be73d0edaa629