### PR TITLE
Use sqlite fallback when DATABASE_URL missing and set env in tests

### DIFF
--- a/backend/app/core/config.py
+++ b/backend/app/core/config.py
@@ -16,7 +16,9 @@ class Settings(BaseSettings):
     """
 
     # === 基本 ===
-    DATABASE_URL: str = os.getenv("DATABASE_URL", "")
+    DATABASE_URL: str = os.getenv(
+        "DATABASE_URL", "sqlite+aiosqlite:///:memory:"
+    )
     SECRET_KEY: str = os.getenv("SECRET_KEY", "your_default_secret_key")
 
     # === 環境/挙動フラグ ===

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -1,3 +1,4 @@
+import os
 import pytest
 import asyncio
 from typing import AsyncGenerator, Generator
@@ -5,12 +6,15 @@ from httpx import AsyncClient
 from sqlalchemy.ext.asyncio import create_async_engine, AsyncSession
 from sqlalchemy.orm import sessionmaker
 
+# テスト用のデータベースURL
+TEST_DATABASE_URL = (
+    "postgresql+asyncpg://ai_secretary_user:ai_secretary_password@postgres_test:5432/ai_secretary_test"
+)
+os.environ.setdefault("DATABASE_URL", TEST_DATABASE_URL)
+
 from app.main import app
 from app.core.database import get_async_db
 from app.models.models import Base
-
-# テスト用のデータベースURL
-TEST_DATABASE_URL = "postgresql+asyncpg://ai_secretary_user:ai_secretary_password@postgres_test:5432/ai_secretary_test"
 
 engine = create_async_engine(TEST_DATABASE_URL)
 TestingSessionLocal = sessionmaker(


### PR DESCRIPTION
## Summary
- Default `DATABASE_URL` to in-memory SQLite when environment variable is absent
- Ensure tests define `DATABASE_URL` before importing the app

## Testing
- `pytest -q` *(fails: socket.gaierror: [Errno -2] Name or service not known)*

------
https://chatgpt.com/codex/tasks/task_e_68c30ec41af88330a066b1ef48d3bd16