### PR TITLE
fix(frontend): install dev dependencies for production build

### DIFF
--- a/frontend/Dockerfile.production
+++ b/frontend/Dockerfile.production
@@ -8,7 +8,7 @@ WORKDIR /app
 COPY package*.json ./
 
 # Install dependencies
-RUN npm ci --only=production
+RUN npm ci
 
 # Copy source code
 COPY . .
@@ -16,6 +16,8 @@ COPY . .
 # Build the application
 RUN npm run build
 
+# Remove development dependencies
+RUN npm prune --omit=dev
 # Production stage
 FROM nginx:alpine
 


### PR DESCRIPTION
## Summary
- install dev dependencies during frontend production build
- prune development packages after build to keep image lean

## Testing
- `docker build -f frontend/Dockerfile.production frontend` *(fails: command not found: docker)*

------
https://chatgpt.com/codex/tasks/task_e_68c833d9bd2483308079dab2e69a2180