### PR TITLE
Add coverage threshold to backend pytest configuration

### DIFF
--- a/backend/pytest.ini
+++ b/backend/pytest.ini
@@ -1,4 +1,4 @@
 [pytest]
 asyncio_mode = auto
 python_files = tests/**/test_*.py
-addopts = -v --cov=app --cov-report=term-missing
+addopts = -v --cov=app --cov-report=term-missing --cov-fail-under=85


### PR DESCRIPTION
## Summary
- add the pytest coverage fail-under threshold alongside existing coverage options

## Testing
- pytest *(fails: sqlalchemy.exc.ArgumentError: Could not parse SQLAlchemy URL from string '')*

------
https://chatgpt.com/codex/tasks/task_e_68c9a931220c83309e6f7f073e165629